### PR TITLE
Handle failed audio start before toggling playback

### DIFF
--- a/app/hooks/useDrumSequencer.ts
+++ b/app/hooks/useDrumSequencer.ts
@@ -133,8 +133,13 @@ export function useDrumSequencer() {
     if (!isClient) return;
 
     // Start audio context if needed (must be triggered by user interaction)
-    await startAudioContext();
-    setIsPlaying(!isPlaying);
+    const audioStarted = await startAudioContext();
+    if (audioStarted) {
+      setIsPlaying(!isPlaying);
+    } else {
+      console.error("Audio context failed to start");
+      alert("Unable to start audio. Please check your browser settings and try again.");
+    }
   };
 
   // Clear sequence


### PR DESCRIPTION
## Summary
- handle play/pause based on audio context start result
- log and alert when audio context fails to start

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59bebc168832c9f316bae586c4aec